### PR TITLE
Filter workflow runs by current event name

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -2,6 +2,10 @@ import assert from 'assert'
 import { ListChecksQuery } from './generated/graphql.js'
 import { CheckConclusionState, CheckStatusState } from './generated/graphql-types.js'
 
+export type Filter = {
+  event: string
+}
+
 export type WorkflowEvent = {
   workflowRuns: WorkflowRun[]
   startedAt: Date | undefined
@@ -26,7 +30,7 @@ export type Job = {
   completedAt: Date
 }
 
-export const summaryListChecksQuery = (q: ListChecksQuery): WorkflowEvent => {
+export const summaryListChecksQuery = (q: ListChecksQuery, filter: Filter): WorkflowEvent => {
   assert(q.rateLimit != null)
   assert(q.repository != null)
   assert(q.repository.object != null)
@@ -40,6 +44,9 @@ export const summaryListChecksQuery = (q: ListChecksQuery): WorkflowEvent => {
     assert(checkSuite.workflowRun != null)
     assert(checkSuite.checkRuns != null)
     assert(checkSuite.checkRuns.nodes != null)
+    if (checkSuite.workflowRun.event !== filter.event) {
+      continue
+    }
 
     const jobs: Job[] = []
     for (const checkRun of checkSuite.checkRuns.nodes) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -24,7 +24,9 @@ export const run = async (inputs: Inputs): Promise<void> => {
     oid: inputs.sha,
     appId: GITHUB_ACTIONS_APP_ID,
   })
-  const event = summaryListChecksQuery(listChecksQuery)
+  const event = summaryListChecksQuery(listChecksQuery, {
+    event: inputs.event,
+  })
   core.info(`event: ${JSON.stringify(event, undefined, 2)}`)
 
   emitSpans(event, inputs)

--- a/tests/checks.test.ts
+++ b/tests/checks.test.ts
@@ -1,9 +1,10 @@
 import { summaryListChecksQuery } from '../src/checks.js'
 import { CheckConclusionState, CheckStatusState } from '../src/generated/graphql-types.js'
+import { ListChecksQuery } from '../src/generated/graphql.js'
 
 describe('summaryListChecksQuery', () => {
   it('should return a summary of workflow runs', () => {
-    const event = summaryListChecksQuery({
+    const query: ListChecksQuery = {
       __typename: 'Query',
       rateLimit: {
         cost: 1,
@@ -53,6 +54,9 @@ describe('summaryListChecksQuery', () => {
           },
         },
       },
+    }
+    const event = summaryListChecksQuery(query, {
+      event: 'push',
     })
     expect(event).toEqual({
       workflowRuns: [


### PR DESCRIPTION
## Problem to solve
`ListChecksQuery` may contain workflow runs triggered by other events. It would be nice to filter them by the current event name of `github.event_name`.
